### PR TITLE
Remove flame/framework dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
 
     "require":{
         "php":">=5.3.2",
-		"ext-curl":"*",
-        "flame/framework": ">=2.0.0"
+		"ext-curl":"*"
     },
 
     "require-dev": {


### PR DESCRIPTION
`flame/framework` wasn't even used in this package. We should remove the dependency.